### PR TITLE
Instagram Graph API 연동 + Follow API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 	// 스프링 시큐리티를 테스트하기 위한 의존성 추가
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	//selenium -> 인스타 크롤링 (셀럽 검색, 피드 가져오기)
+	implementation 'org.seleniumhq.selenium:selenium-java:4.6.0'
+
+	implementation group: 'org.json', name: 'json', version: '20160810'
 
 	//validation 지원 x -> ingection
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/example/stylescanner/follow/api/FollowApi.java
+++ b/src/main/java/com/example/stylescanner/follow/api/FollowApi.java
@@ -1,0 +1,42 @@
+package com.example.stylescanner.follow.api;
+
+import com.example.stylescanner.follow.dto.FollowingListResponseDto;
+import com.example.stylescanner.follow.dto.FollowingRequestDto;
+import com.example.stylescanner.follow.dto.UnFollowingRequestDto;
+import com.example.stylescanner.follow.entity.Follow;
+import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/api/follow")
+@Tag(name = "Follow", description = "팔로우 API")
+public interface FollowApi {
+    @GetMapping("")
+    @Operation(summary = "팔로잉 목록 조회 메서드", description = "모든 팔로잉 데이터 목록을 보여주는 메서드입니다.")
+    List<Follow> list();
+
+    @GetMapping("/{id}")
+    @Operation(summary = "팔로잉 상세 조회 메서드", description = "해당 팔로잉 데이터를 보여주는 메서드입니다. 없으면 IllegalException")
+    ResponseEntity<Follow> read(@PathVariable Long id);
+
+    @GetMapping("/search")
+    @Operation(summary = "셀럽 검색 메서드", description = "셀럽 계정을 검색하여 검색 결과를 보여주는 메서드입니다.")
+    ResponseEntity<CelebProfileResponseDto> search(@RequestParam(value="keyword") String keyword);
+
+    @PostMapping("/following")
+    @Operation(summary = "팔로잉 메서드", description = "사용자의 토큰값과 팔로잉 셀럽 followeeId을 넘겨주면 해당 셀럽의 팔로잉 정보를 DB에 저장합니다.")
+    ResponseEntity<Boolean> follow(HttpServletRequest httpServletRequest, @RequestBody FollowingRequestDto requestDto);
+
+    @GetMapping("/followingList")
+    @Operation(summary = "사용자 팔로잉 목록 메서드", description = "현재 사용자의 팔로잉 목록을 반환하는 메서드입니다.")
+    ResponseEntity<FollowingListResponseDto> followingList(HttpServletRequest httpServletRequest);
+
+    @PostMapping("/unfollowing")
+    @Operation(summary = "사용자 언팔로잉 메서드", description = "언팔로잉 하는 셀럽 followeeId를 넘겨주면 해당 셀럽의 팔로잉을 정보를 제거합니다.")
+    ResponseEntity<Boolean> unfollow(HttpServletRequest request, @RequestBody UnFollowingRequestDto requestDto);
+}

--- a/src/main/java/com/example/stylescanner/follow/controller/FollowController.java
+++ b/src/main/java/com/example/stylescanner/follow/controller/FollowController.java
@@ -1,0 +1,58 @@
+package com.example.stylescanner.follow.controller;
+
+import com.example.stylescanner.follow.api.FollowApi;
+import com.example.stylescanner.follow.dto.FollowingListResponseDto;
+import com.example.stylescanner.follow.dto.FollowingRequestDto;
+import com.example.stylescanner.follow.dto.UnFollowingRequestDto;
+import com.example.stylescanner.follow.entity.Follow;
+import com.example.stylescanner.follow.service.FollowService;
+import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
+import com.example.stylescanner.jwt.provider.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController implements FollowApi {
+    private final FollowService followService;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public List<Follow> list() {
+        return followService.list();
+    }
+
+    @Override
+    public ResponseEntity<Follow> read(Long id) {
+        return ResponseEntity.ok(followService.read(id));
+    }
+
+    @Override
+    public ResponseEntity<CelebProfileResponseDto> search(String keyword)
+    {
+        return ResponseEntity.ok(followService.search(keyword));
+    }
+
+    @Override
+    public ResponseEntity<Boolean> follow(HttpServletRequest request, FollowingRequestDto requestDto) {
+        String email = jwtProvider.getAccount(jwtProvider.resolveToken(request).substring(7));
+
+        return ResponseEntity.ok(followService.follow(email,requestDto));
+    }
+
+    @Override
+    public ResponseEntity<FollowingListResponseDto> followingList(HttpServletRequest request) {
+        String email = jwtProvider.getAccount(jwtProvider.resolveToken(request).substring(7));
+        return ResponseEntity.ok(followService.followingList(email));
+    }
+
+    @Override
+    public ResponseEntity<Boolean> unfollow(HttpServletRequest request, UnFollowingRequestDto requestDto) {
+        String email = jwtProvider.getAccount(jwtProvider.resolveToken(request).substring(7));
+        return ResponseEntity.ok(followService.unfollow(email,requestDto));
+    }
+}

--- a/src/main/java/com/example/stylescanner/follow/dto/FollowSearchRequestDto.java
+++ b/src/main/java/com/example/stylescanner/follow/dto/FollowSearchRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.stylescanner.follow.dto;
+
+import lombok.Data;
+
+@Data
+public class FollowSearchRequestDto {
+    private String keyword;
+}

--- a/src/main/java/com/example/stylescanner/follow/dto/FollowingListResponseDto.java
+++ b/src/main/java/com/example/stylescanner/follow/dto/FollowingListResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.stylescanner.follow.dto;
+
+import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FollowingListResponseDto {
+    private List<CelebProfileResponseDto> following_list;
+}

--- a/src/main/java/com/example/stylescanner/follow/dto/FollowingRequestDto.java
+++ b/src/main/java/com/example/stylescanner/follow/dto/FollowingRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.stylescanner.follow.dto;
+
+import lombok.Data;
+
+@Data
+public class FollowingRequestDto {
+    private String followeeId;  //셀럽 아이디 ex) you_r_love
+}

--- a/src/main/java/com/example/stylescanner/follow/dto/UnFollowingRequestDto.java
+++ b/src/main/java/com/example/stylescanner/follow/dto/UnFollowingRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.stylescanner.follow.dto;
+
+import lombok.Data;
+
+@Data
+public class UnFollowingRequestDto {
+    private String followeeId;
+}

--- a/src/main/java/com/example/stylescanner/follow/entity/Follow.java
+++ b/src/main/java/com/example/stylescanner/follow/entity/Follow.java
@@ -34,5 +34,6 @@ public class Follow {
     public Follow(String followeeId, User user) {
         this.followeeId = followeeId;
         this.user = user;
+        this.createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
@@ -1,0 +1,13 @@
+package com.example.stylescanner.follow.repository;
+
+import com.example.stylescanner.follow.entity.Follow;
+import com.example.stylescanner.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    List<Follow> findByUser(User user);
+    Optional<Follow> findByUserAndFolloweeId(User user, String followeeId);
+}

--- a/src/main/java/com/example/stylescanner/follow/service/FollowService.java
+++ b/src/main/java/com/example/stylescanner/follow/service/FollowService.java
@@ -1,0 +1,96 @@
+package com.example.stylescanner.follow.service;
+
+import com.example.stylescanner.follow.dto.FollowingListResponseDto;
+import com.example.stylescanner.follow.dto.FollowingRequestDto;
+import com.example.stylescanner.follow.dto.UnFollowingRequestDto;
+import com.example.stylescanner.follow.entity.Follow;
+import com.example.stylescanner.follow.repository.FollowRepository;
+import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
+import com.example.stylescanner.instagram.util.InstagramGraphApiUtil;
+import com.example.stylescanner.user.entity.User;
+import com.example.stylescanner.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class FollowService {
+    private final FollowRepository followRepository;
+
+    @Autowired
+    private final InstagramGraphApiUtil instagramGraphApiUtil;
+    @Autowired
+    private UserRepository userRepository;
+
+    public FollowService(UserRepository userRepository, FollowRepository followRepository, InstagramGraphApiUtil instagramGraphApiUtil) {
+        this.followRepository = followRepository;
+        this.instagramGraphApiUtil = instagramGraphApiUtil;
+    }
+
+    public List<Follow> list() {
+        return followRepository.findAll();
+    }
+
+    public Follow read(Long id) {
+        return followRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("not found follow"));
+    }
+
+    public CelebProfileResponseDto search(String keyword) {
+        System.out.println(keyword);
+        try {
+            return instagramGraphApiUtil.SearchCeleb(keyword);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Boolean follow(String email, FollowingRequestDto requestDto) {
+        User user =  userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("not found user"));
+
+        Follow follow = Follow.builder()
+                .followeeId(requestDto.getFolloweeId())
+                .user(user)
+                .build();
+
+        followRepository.save(follow);
+        return true;
+    }
+
+    public FollowingListResponseDto followingList(String email)
+    {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("not found user"));
+
+        List<Follow> follows = followRepository.findByUser(user);
+        FollowingListResponseDto responseDto = new FollowingListResponseDto();
+        List<CelebProfileResponseDto> celebProfileList = new ArrayList<>();
+
+        for (Follow follow : follows) {
+            String followeeId = follow.getFolloweeId();
+            CelebProfileResponseDto celebProfileResponseDto = null;
+            try {
+                celebProfileResponseDto = instagramGraphApiUtil.SearchCeleb(followeeId);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+             celebProfileList.add(celebProfileResponseDto);
+        }
+        responseDto.setFollowing_list(celebProfileList);
+
+        return responseDto;
+    }
+
+    public Boolean unfollow(String email, UnFollowingRequestDto requestDto) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("not found user"));
+
+        String followeeId = requestDto.getFolloweeId();
+        Follow follow = followRepository.findByUserAndFolloweeId(user, followeeId).orElseThrow(() -> new IllegalArgumentException("not found follow"));
+
+        followRepository.delete(follow);
+
+        return true;
+    }
+}

--- a/src/main/java/com/example/stylescanner/instagram/dto/CelebProfileResponseDto.java
+++ b/src/main/java/com/example/stylescanner/instagram/dto/CelebProfileResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.stylescanner.instagram.dto;
+
+import lombok.Data;
+
+@Data
+public class CelebProfileResponseDto {
+    private String profilePictureUrl;
+    private String profileName;
+    private int profileFollowerCount;
+}

--- a/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
+++ b/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
@@ -1,0 +1,53 @@
+package com.example.stylescanner.instagram.util;
+
+import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+@Component
+public class InstagramGraphApiUtil {
+    private String API_URL = "https://graph.facebook.com/v19.0/";
+
+    @Value("${instagram-graph-api.access-token}")
+    private String ACCESS_TOKEN;
+
+    @Value("${instagram-graph-api.ig-user-id}")
+    private String IG_USER_ID ;
+
+    /**
+     *  셀럽 검색 : 존재하면 프로필 정보 리턴, 없으면 오류 메시지 리턴
+     */
+    public CelebProfileResponseDto SearchCeleb(String celeb_id) throws IOException, JSONException {
+        String url_format = String.format("?fields=business_discovery.username(%s){username,followers_count,profile_picture_url}&access_token=%s", celeb_id, ACCESS_TOKEN);
+        URL url = new URL(API_URL +IG_USER_ID + url_format);
+
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setDoOutput(true);
+
+        BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+        StringBuilder sb=new StringBuilder();
+        String line = null;
+
+        while((line = rd.readLine()) != null) {
+            sb.append(line);
+        }
+
+        JSONObject obj = new JSONObject(sb.toString());
+        JSONObject businessDiscovery = obj.getJSONObject("business_discovery");
+
+        CelebProfileResponseDto celebProfileResponseDto = new CelebProfileResponseDto();
+        celebProfileResponseDto.setProfileName(businessDiscovery.getString("username"));
+        celebProfileResponseDto.setProfilePictureUrl(businessDiscovery.getString("profile_picture_url"));
+        celebProfileResponseDto.setProfileFollowerCount(businessDiscovery.getInt("followers_count"));
+        return celebProfileResponseDto;
+    }
+}

--- a/src/main/java/com/example/stylescanner/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/example/stylescanner/jwt/provider/JwtProvider.java
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 
-@RequiredArgsConstructor
+
 @Component
 public class JwtProvider {
 
@@ -31,6 +31,10 @@ public class JwtProvider {
     private final long refreshExp = 1000L * 60 * 60 * 24 * 14; // 14 days in milliseconds
 
     private final JpaUserDetailsService userDetailsService;
+
+    public JwtProvider(JpaUserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
 
     @PostConstruct
     protected void init() {

--- a/src/main/java/com/example/stylescanner/user/api/UserApi.java
+++ b/src/main/java/com/example/stylescanner/user/api/UserApi.java
@@ -44,4 +44,8 @@ public interface UserApi {
     @PostMapping("/withdrawal")
     @Operation(summary = "사용자 탈퇴 메서드", description = "사용자가 탈퇴하는 메서드입니다. ")
     ResponseEntity<Boolean> withdrawal(HttpServletRequest request);
+
+    @GetMapping("/emailcheck")
+    @Operation(summary="이메일 중복 확인 메서드", description = "이메일을 받아 존재하는지 확인하는 메서드입니다.")
+    ResponseEntity<Boolean> emailcheck(@RequestParam(value = "email") String email);
 }

--- a/src/main/java/com/example/stylescanner/user/controller/UserController.java
+++ b/src/main/java/com/example/stylescanner/user/controller/UserController.java
@@ -59,8 +59,12 @@ public class UserController implements UserApi {
     @Override
     public ResponseEntity<Boolean> withdrawal(HttpServletRequest request) {
         String email = jwtProvider.getAccount(jwtProvider.resolveToken(request).substring(7));
-
         return ResponseEntity.ok(userService.withdrawal(email));
+    }
+
+    @Override
+    public ResponseEntity<Boolean> emailcheck(String email) {
+        return ResponseEntity.ok(userService.emailcheck(email));
     }
 
 

--- a/src/main/java/com/example/stylescanner/user/repository/UserRepository.java
+++ b/src/main/java/com/example/stylescanner/user/repository/UserRepository.java
@@ -8,5 +8,4 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     //중복 가입 확인
     Optional<User> findByEmail(String email);
-
 }

--- a/src/main/java/com/example/stylescanner/user/service/UserService.java
+++ b/src/main/java/com/example/stylescanner/user/service/UserService.java
@@ -114,4 +114,13 @@ public class UserService  {
         userRepository.delete(user);
         return true;
     }
+
+    public Boolean emailcheck(String email) {
+        Optional<User> checkUserEmail = userRepository.findByEmail(email);
+        if(checkUserEmail.isPresent()) {
+            return true;
+        }else{
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
고봉밥 pr 입니다.... 

### User API 추가 
- 이메일 중복 확인 메서드 emailcheck() 추가 

### Instagram Graph API 연동 Util - InstagramGraphApiUtil 
- 셀럽 검색 메서드 SearchCeleb() 구현 

### Follow API 구현 
- 셀럽 검색 메서드 search()  
- 팔로잉 메서드 follow() 
- 사용자 팔로잉 목록 메서드 followingList()  
- 언팔로잉 메서드 unfollow() 
