### PR TITLE
셀럽 검색 및 팔로잉 일부 기능 수정 

### DIFF
--- a/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findByUser(User user);
     Optional<Follow> findByUserAndFolloweeId(User user, String followeeId);
+    boolean existsByFolloweeIdAndUser(String followeeId, User user);
 }

--- a/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
+++ b/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
@@ -39,17 +39,35 @@ public class InstagramGraphApiUtil {
         conn.setRequestMethod("GET");
         conn.setDoOutput(true);
 
-        BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-        StringBuilder sb=new StringBuilder();
-        String line = null;
+        int responseCode = conn.getResponseCode();
 
-        while((line = rd.readLine()) != null) {
-            sb.append(line);
+        if(responseCode == 200) {
+            BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            StringBuilder sb=new StringBuilder();
+            String line = null;
+
+            while((line = rd.readLine()) != null) {
+                sb.append(line);
+            }
+
+            JSONObject obj = new JSONObject(sb.toString());
+
+            return obj;
+        }else{
+            BufferedReader in = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            String inputLine;
+            StringBuilder response = new StringBuilder();
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+
+            if (response.toString().contains("Invalid user id")) {
+                return null;
+            }
         }
 
-        JSONObject obj = new JSONObject(sb.toString());
-
-        return obj;
+        return null;
     }
 
     /**
@@ -60,6 +78,11 @@ public class InstagramGraphApiUtil {
         URL url = new URL(API_URL + IG_USER_ID + url_format);
 
         JSONObject obj = GetAPIData(url);
+
+        if(obj == null){
+            return null;
+        }
+
         JSONObject businessDiscovery = obj.getJSONObject("business_discovery");
         CelebProfileResponseDto celebProfileResponseDto = new CelebProfileResponseDto();
         celebProfileResponseDto.setProfileName(celeb_id);
@@ -187,7 +210,6 @@ public class InstagramGraphApiUtil {
 
                 if(data.has("children")){
                     JSONArray children = data.getJSONObject("children").getJSONArray("data");
-                    System.out.println(children);
                     for(int j=1; j<children.length(); j++) {
                         media_url.add(children.getJSONObject(j).getString("media_url"));
                     }


### PR DESCRIPTION
### 📌InstagramGraphApiUtil - 셀럽 검색 기능 수정 
존재하지 않는 셀럽 계정에 대한 처리가 잘못되어 있었는데 수정하였습니다. 
--> 존재하지 않는 셀럽 계정 아이디 요청 시 null 반환

### 📌FollowService - 팔로잉 기능 수정 
중복 팔로잉 방지 --> 중복 팔로잉 일 경우 false 반환 
존재 하지 않는 셀럽 계정 팔로잉 방지  --> 존재하지 않는 계정일 경우 false 반환 

##### ps. instagram graph api 가 알고보니 이전에 계정 아이디(@~) 를 바꾼적이 있으면 현재 계정 아이디로 API를 호출해도 찾지 못하는 아주 심각한 버그(?)가 있네요,,,,,,,,,,,, 일단은 아이디 바꾼적 없는 셀럽들만 검색/팔로잉/프로필/피드를 가져올 수 있는데 이부분은 어느정도 구현 다 되면 어떤 방법으로 해결할지 고민해봅시다요 