### PR TITLE
searchFeed구현 및 셀럽 인스타 반환 API 일부 수정 

### DIFF
--- a/src/main/java/com/example/stylescanner/follow/service/FollowService.java
+++ b/src/main/java/com/example/stylescanner/follow/service/FollowService.java
@@ -93,7 +93,9 @@ public class FollowService {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-             celebProfileList.add(celebProfileResponseDto);
+            if(celebProfileResponseDto != null){
+                celebProfileList.add(celebProfileResponseDto);
+            }
         }
         responseDto.setFollowing_list(celebProfileList);
 

--- a/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
+++ b/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
@@ -1,12 +1,15 @@
 package com.example.stylescanner.instagram.api;
 
 import com.example.stylescanner.instagram.dto.CelebInstaResponseDto;
+import com.example.stylescanner.instagram.dto.FeedDto;
+import com.example.stylescanner.instagram.dto.FeedRequestDto;
 import com.example.stylescanner.instagram.dto.HomeFeedResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping("/api/insta")
@@ -17,7 +20,10 @@ public interface InstagramApi {
     CelebInstaResponseDto readCelebInsta(@PathVariable("username") String username);
 
     @GetMapping("/home")
-    @Operation(summary="홈 화면 속 피드 리스트 요청 메서드", description = "사용자가 팔로잉 하고있는 셀럽의 모든 피드를 가져옵니다.")
+    @Operation(summary="홈 화면 속 피드 리스트 요청 메서드", description = "사용자가 팔로잉 하고있는 셀럽의 가장 최근 피드를 가져옵니다.")
     HomeFeedResponseDto getHomeFeed(HttpServletRequest request);
 
+    @GetMapping("/feed")
+    @Operation(summary = "셀럽 계정 속 특정 피드 요청 메서드", description = "선택한 피드의 인덱스값과 미디어 아이디를 넘겨주면 해당 피드의 하위 피드를 가져옵니다.")
+    FeedDto getFeed(@RequestBody FeedRequestDto feedRequestDto);
 }

--- a/src/main/java/com/example/stylescanner/instagram/controller/InstagramController.java
+++ b/src/main/java/com/example/stylescanner/instagram/controller/InstagramController.java
@@ -4,6 +4,8 @@ import com.example.stylescanner.follow.dto.FollowingListResponseDto;
 import com.example.stylescanner.follow.service.FollowService;
 import com.example.stylescanner.instagram.api.InstagramApi;
 import com.example.stylescanner.instagram.dto.CelebInstaResponseDto;
+import com.example.stylescanner.instagram.dto.FeedDto;
+import com.example.stylescanner.instagram.dto.FeedRequestDto;
 import com.example.stylescanner.instagram.dto.HomeFeedResponseDto;
 import com.example.stylescanner.instagram.service.InstagramService;
 import com.example.stylescanner.jwt.provider.JwtProvider;
@@ -28,5 +30,10 @@ public class InstagramController implements InstagramApi {
         String email = jwtProvider.getAccount(jwtProvider.resolveToken(request).substring(7));
         FollowingListResponseDto followingList =  followService.followingList(email);
         return instagramService.readHomeFeed(followingList);
+    }
+
+    @Override
+    public FeedDto getFeed(FeedRequestDto feedRequestDto) {
+        return instagramService.readFeed(feedRequestDto);
     }
 }

--- a/src/main/java/com/example/stylescanner/instagram/dto/FeedDto.java
+++ b/src/main/java/com/example/stylescanner/instagram/dto/FeedDto.java
@@ -12,4 +12,6 @@ public class FeedDto {
     String profile_url;
     LocalDateTime timestamp;
     String media_id;
+    int feed_index;
+    String before_cursor;
 }

--- a/src/main/java/com/example/stylescanner/instagram/dto/FeedRequestDto.java
+++ b/src/main/java/com/example/stylescanner/instagram/dto/FeedRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.stylescanner.instagram.dto;
+
+import lombok.Data;
+
+@Data
+public class FeedRequestDto {
+    String username;
+    String before_cursor;
+    String media_id;
+    String feed_index;
+}

--- a/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
+++ b/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
@@ -57,4 +57,13 @@ public class InstagramService {
 
         return homeFeedResponseDto;
     }
+
+    public FeedDto readFeed(FeedRequestDto feedRequestDto) {
+        String mediaId = feedRequestDto.getMedia_id();
+        String feedIndex = feedRequestDto.getFeed_index();
+        int feed_index = Integer.parseInt(feedIndex) % 25;
+        String beforeCursor = feedRequestDto.getBefore_cursor();
+        String username = feedRequestDto.getUsername();
+        return instagramGraphApiUtil.GetMedia(username,  mediaId, beforeCursor,feed_index);
+    }
 }


### PR DESCRIPTION
closes #31 

### 📍추가 내역
- 셀럽 인스타 피드 중 특정 피드 클릭시 해당 피드의 하위 미디어 정보 반환하는 API 개발 (**/api/insta/feed**) 

### 📍수정 내역
- 셀럽 인스타 피드(**/api/insta/{username}**) 호출 시 **before_cursor, feed_index 정보도 반환**됨 --> 이 정보를 피드 호출시 인스타 셀럽의 아이디(username)과 해당 피드의 미디어 아이디(media_id)와 함께 RequestBody에 넣어서 /api/insta/feed 호출해야함 

#### 📍 before_cursor, feed_index 쓰는 이유 :  해당 피드의 위치를 최대한 특정해서 과부하와 시간 복잡도를 줄이기 위해서 씁니다.  

---

### /api/insta/{username} 수정 후 반환 결과 
<img width="737" alt="image" src="https://github.com/comprehensive-design/style-scanner-backend/assets/117638449/5e4468aa-2635-4ad2-b7cb-587695418ede">
before_cursor, feed_index가 추가됨 
위 이미지는 2021-9-5 포스팅 된 피드의 젤 첫 이미지 

### Case : before_cursor가 없는 경우는 안넣어서 보내도 잘 돌아감 (최근 25개 피드 안에 들면 before_cursor가 null로 반환됩니다) 
<img width="935" alt="image" src="https://github.com/comprehensive-design/style-scanner-backend/assets/117638449/eba40530-205c-4a60-8a42-92f3ff5aae33">

### Case : before_cursor가 있는 경우 (있는 경우는 최근 25개 피드 이후에 포스팅된 피드인 경우) 
<img width="637" alt="image" src="https://github.com/comprehensive-design/style-scanner-backend/assets/117638449/3fe95e1b-ed42-4cfd-a8c0-f97472c769f7">

앞의 2021-9-5 피드의 나머지 이미지들도 잘 반환됨
