### PR TITLE
셀럽 팔로잉 랭킹 API 구현

### DIFF
--- a/src/main/java/com/example/stylescanner/follow/api/FollowApi.java
+++ b/src/main/java/com/example/stylescanner/follow/api/FollowApi.java
@@ -1,9 +1,6 @@
 package com.example.stylescanner.follow.api;
 
-import com.example.stylescanner.follow.dto.FollowingListResponseDto;
-import com.example.stylescanner.follow.dto.FollowingRequestDto;
-import com.example.stylescanner.follow.dto.RecommendResponseDto;
-import com.example.stylescanner.follow.dto.UnFollowingRequestDto;
+import com.example.stylescanner.follow.dto.*;
 import com.example.stylescanner.follow.entity.Follow;
 import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -48,5 +45,9 @@ public interface FollowApi {
     @GetMapping("/recommend")
     @Operation(summary = "셀럽 추천 메서드", description = "현재 사용자의 팔로잉 목록을 바탕으로 다른 셀럽 계정을 추천합니다.")
     List<RecommendResponseDto> recommend(HttpServletRequest httpServletRequest);
+
+    @GetMapping("/ranking")
+    @Operation(summary = "셀럽 랭킹 메서드", description = "현재 시스템에서 가장 많이 팔로잉된 순으로 셀럽 계정 목록을 반환합니다.")
+    List<CelebRankingResponseDto> ranking();
 
 }

--- a/src/main/java/com/example/stylescanner/follow/controller/FollowController.java
+++ b/src/main/java/com/example/stylescanner/follow/controller/FollowController.java
@@ -1,10 +1,7 @@
 package com.example.stylescanner.follow.controller;
 
 import com.example.stylescanner.follow.api.FollowApi;
-import com.example.stylescanner.follow.dto.FollowingListResponseDto;
-import com.example.stylescanner.follow.dto.FollowingRequestDto;
-import com.example.stylescanner.follow.dto.RecommendResponseDto;
-import com.example.stylescanner.follow.dto.UnFollowingRequestDto;
+import com.example.stylescanner.follow.dto.*;
 import com.example.stylescanner.follow.entity.Follow;
 import com.example.stylescanner.follow.service.FollowService;
 import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
@@ -67,5 +64,10 @@ public class FollowController implements FollowApi {
     public List<RecommendResponseDto> recommend(HttpServletRequest httpServletRequest) {
         String email = jwtProvider.getAccount(jwtProvider.resolveToken(httpServletRequest).substring(7));
         return followService.recommend(email);
+    }
+
+    @Override
+    public List<CelebRankingResponseDto> ranking() {
+        return followService.ranking();
     }
 }

--- a/src/main/java/com/example/stylescanner/follow/dto/CelebRankingResponseDto.java
+++ b/src/main/java/com/example/stylescanner/follow/dto/CelebRankingResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.stylescanner.follow.dto;
+
+import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CelebRankingResponseDto {
+    CelebProfileResponseDto profile;
+    Long followingCount;
+
+    public CelebRankingResponseDto(CelebProfileResponseDto celebProfile, Long followingCount) {
+        this.profile = celebProfile;
+        this.followingCount = followingCount;
+    }
+}

--- a/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
@@ -27,4 +27,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
             "ORDER BY count DESC")
     List<Map<String, Object>> findRecommendedFolloweesWithCount(@Param("followeeIds") List<String> followeeIds, @Param("user") User user);
 
+
+    @Query("SELECT f.followeeId, COUNT(f.followeeId) AS followCount " +
+            "FROM Follow f " +
+            "GROUP BY f.followeeId " +
+            "ORDER BY followCount DESC")
+    List<Object[]> findTopFollowedCelebrities();
 }

--- a/src/main/java/com/example/stylescanner/follow/service/FollowService.java
+++ b/src/main/java/com/example/stylescanner/follow/service/FollowService.java
@@ -1,9 +1,6 @@
 package com.example.stylescanner.follow.service;
 
-import com.example.stylescanner.follow.dto.FollowingListResponseDto;
-import com.example.stylescanner.follow.dto.FollowingRequestDto;
-import com.example.stylescanner.follow.dto.RecommendResponseDto;
-import com.example.stylescanner.follow.dto.UnFollowingRequestDto;
+import com.example.stylescanner.follow.dto.*;
 import com.example.stylescanner.follow.entity.Follow;
 import com.example.stylescanner.follow.repository.FollowRepository;
 import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
@@ -162,5 +159,11 @@ public class FollowService {
             cnt++;
         }
         return recommendedResponseDtoList;
+    }
+
+    public List<CelebRankingResponseDto> ranking() {
+        List<Object[]> celebRankingList = followRepository.findTopFollowedCelebrities();
+        List<CelebRankingResponseDto> celebRankingResponseDtoList = celebRankingList.stream().limit(5).map(result -> new CelebRankingResponseDto((CelebProfileResponseDto) search((String) result[0]), (Long) result[1])).collect(Collectors.toList());
+        return celebRankingResponseDtoList;
     }
 }


### PR DESCRIPTION
### 📍구현 : 셀럽 팔로잉 랭킹 /api/follow/ranking
params, request body, header 필요 x 
현재 시스템에서 팔로잉 랭킹 상위 5명 셀럽을 내림차순으로 반환합니다. 

셀럽 프로필 : profile
해당 셀럽의 팔로잉 수 : followingCount  

### ⭕ 테스트 이미지
<img width="480" alt="image" src="https://github.com/comprehensive-design/style-scanner-backend/assets/117638449/1cc56863-12f7-4468-a20c-f41249dc53d4">

