### PR TITLE
아이템 카테고리별 조회 기능, 랭킹 필터 구현

### DIFF
--- a/src/main/java/com/example/stylescanner/item/api/ItemApi.java
+++ b/src/main/java/com/example/stylescanner/item/api/ItemApi.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -16,12 +17,12 @@ import java.util.List;
 @Tag(name = "Item", description = "아이템 API")
 public interface ItemApi {
     @GetMapping("")
-    @Operation(summary = "아이템 목록 조회 메서드", description = "아이템 목록을 조회하기 위한 메서드입니다.")
-    List<ItemDto> list();
+    @Operation(summary = "아이템 목록 조회 메서드", description = "카테고리별 아이템 목록을 조회하기 위한 메서드입니다.")
+    List<ItemDto> list(@RequestParam String category);
 
     @GetMapping("/ranking")
-    @Operation(summary = "아이템 좋아요순 목록 조회 메서드", description = "아이템 목록을 좋아요순으로 조회하기 위한 메서드입니다.")
-    List<ItemDto> ranking();
+    @Operation(summary = "아이템 랭킹 조회 메서드", description = "아이템의 랭킹을 조회하기 위한 메서드입니다.")
+    List<ItemDto> ranking(@RequestParam String category, @RequestParam int timeFilter);
 
     @GetMapping("/{id}")
     @Operation(summary = "아이템 상세 조회 메서드", description = "아이템의 상세 내용을 조회하기 위한 메서드입니다.")

--- a/src/main/java/com/example/stylescanner/item/category/Category.java
+++ b/src/main/java/com/example/stylescanner/item/category/Category.java
@@ -8,8 +8,8 @@ import java.util.stream.Collectors;
 
 @Getter
 public enum Category {
-    ROOT("전체", null),
-        FASHION_WOMEN("여성", ROOT),
+    ALL("전체", null),
+        FASHION_WOMEN("여성", ALL),
             WOMEN_OUTER("아우터", FASHION_WOMEN),
             WOMEN_TOP("상의", FASHION_WOMEN),
             WOMEN_PANTS("팬츠", FASHION_WOMEN),
@@ -19,7 +19,7 @@ public enum Category {
             WOMEN_BAG("가방", FASHION_WOMEN),
             WOMEN_ACC("악세사리", FASHION_WOMEN),
             WOMEN_ETC("기타", FASHION_WOMEN),
-        FASHION_MEN("남성", ROOT),
+        FASHION_MEN("남성", ALL),
             MEN_OUTER("아우터", FASHION_MEN),
             MEN_TOP("상의", FASHION_MEN),
             MEN_PANTS("팬츠", FASHION_MEN),
@@ -57,6 +57,15 @@ public enum Category {
     // 마지막 카테고리(상품추가 가능)인지 반환
     public boolean isLeafCategory() {
         return childCategories.isEmpty();
+    }
+
+    // 자식카테고리 재귀적으로 반환
+    public List<Category> getAllSubCategories() {
+        List<Category> subCategories = new ArrayList<>(childCategories);
+        for (Category child : childCategories) {
+            subCategories.addAll(child.getAllSubCategories());
+        }
+        return subCategories;
     }
 
     // 마지막 카테고리(상품추가 가능)들 반환

--- a/src/main/java/com/example/stylescanner/item/controller/ItemController.java
+++ b/src/main/java/com/example/stylescanner/item/controller/ItemController.java
@@ -19,19 +19,18 @@ public class ItemController implements ItemApi {
     private final ItemService itemService;
 
     @Override
-    public List<ItemDto> list() {
-        List<Item> items = itemService.list();
+    public List<ItemDto> list(String category) {
+        List<Item> items = itemService.list(category);
         return items.stream()
                 .map(ItemDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<ItemDto> ranking() {
-        List<Item> items = itemService.list();
+    public List<ItemDto> ranking(String category, int timeFilter) {
+        List<Item> items = itemService.ranking(category, timeFilter);
         return items.stream()
                 .map(ItemDto::fromEntity)
-                .sorted((dto1, dto2) -> Integer.compare(dto2.getLikeCount(), dto1.getLikeCount()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/example/stylescanner/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/stylescanner/item/repository/ItemRepository.java
@@ -1,8 +1,18 @@
 package com.example.stylescanner.item.repository;
 
+import com.example.stylescanner.item.category.Category;
 import com.example.stylescanner.item.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Integer>{
+    List<Item> findByCategory(Category category);
+//    List<Item> findByCategoryIn(List<Category> categories);
+
+    @Query("SELECT i FROM Item i LEFT JOIN ItemLike il ON i = il.item WHERE i.category IN :categories GROUP BY i.id ORDER BY COUNT(il) DESC")
+    List<Item> findByCategoryInOrderByLikeCount(@Param("categories") List<Category> categories);
 
 }

--- a/src/main/java/com/example/stylescanner/item/service/ItemService.java
+++ b/src/main/java/com/example/stylescanner/item/service/ItemService.java
@@ -1,23 +1,76 @@
 package com.example.stylescanner.item.service;
 
+import com.example.stylescanner.item.category.Category;
 import com.example.stylescanner.item.entity.Item;
 import com.example.stylescanner.item.repository.ItemRepository;
+import com.example.stylescanner.itemLike.repository.ItemLikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ItemService {
     private final ItemRepository itemRepository;
+    private final ItemLikeRepository itemLikeRepository;
 
 
-    public List<Item> list(){
-        return itemRepository.findAll();
+    public List<Item> list(String category){
+        return getItemsByCategoryName(category);
+    }
+
+    public List<Item> ranking(String category, int timeFilter){
+        List<Item> items = getItemsByCategoryName(category);
+
+        if (timeFilter == 0) {
+            // 전체 기간
+            return items;
+        }
+        LocalDateTime startDate;
+        LocalDateTime endDate = LocalDateTime.now();
+
+        if (timeFilter == 1) {
+            // 오늘 하루 동안 생성된 itemLike
+            startDate = LocalDateTime.of(endDate.toLocalDate(), LocalTime.MIDNIGHT);
+        } else if (timeFilter == 2) {
+            // 일주일 동안 생성도니 itemLike
+            startDate = endDate.minusDays(7);
+        } else {
+            throw new IllegalArgumentException("Invalid time filter");
+        }
+        List<Object[]> likeCounts = itemLikeRepository.findItemLikeCountsBetweenDates(startDate, endDate);
+        Map<Long, Long> likeCountMap = likeCounts.stream()
+                .collect(Collectors.toMap(
+                        entry -> (Long) entry[0],
+                        entry -> (Long) entry[1]
+                ));
+
+        // 좋아요 수 기준으로 아이템 정렬
+        items.sort(Comparator.comparingLong(item -> -likeCountMap.getOrDefault(item.getId(), 0L)));
+
+        return items;
     }
 
     public Item read(Integer id){
         return itemRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 아이템이 없습니다. id= "+ id));
+    }
+
+    public List<Item> getItemsByCategories(List<Category> categories) {
+        return itemRepository.findByCategoryInOrderByLikeCount(categories);
+    }
+    public List<Item> getItemsByCategoryName(String categoryName) {
+        Category category = Category.valueOf(categoryName);
+        List<Category> categories = new ArrayList<>();
+        categories.add(category);
+        categories.addAll(category.getAllSubCategories());
+
+        return getItemsByCategories(categories);
     }
 }

--- a/src/main/java/com/example/stylescanner/itemLike/repository/ItemLikeRepository.java
+++ b/src/main/java/com/example/stylescanner/itemLike/repository/ItemLikeRepository.java
@@ -1,12 +1,22 @@
 package com.example.stylescanner.itemLike.repository;
 
+import com.example.stylescanner.item.entity.Item;
 import com.example.stylescanner.itemLike.entity.ItemLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ItemLikeRepository extends JpaRepository<ItemLike, Integer> {
     ItemLike findByItemIdAndUserId(Integer itemId, Long id);
 
     List<ItemLike> findAllByUserId(Long userId);
+
+    @Query("SELECT il.item FROM ItemLike il GROUP BY il.item ORDER BY COUNT(il) DESC")
+    List<Item> findAllItemsOrderByLikeCount();
+
+    @Query("SELECT il.item.id, COUNT(il) FROM ItemLike il WHERE il.createdAt >= :startDate AND il.createdAt <= :endDate GROUP BY il.item.id")
+    List<Object[]> findItemLikeCountsBetweenDates(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }


### PR DESCRIPTION
## 카테고리 구성

ALL - "전체"
    &emsp;FASHION_WOMEN - "여성"
        &emsp;&emsp;WOMEN_OUTER - "아우터"
        &emsp;&emsp;WOMEN_TOP - "상의"
        &emsp;&emsp;WOMEN_PANTS - "팬츠"
        &emsp;&emsp;WOMEN_SKIRT - "스커트"
        &emsp;&emsp;WOMEN_ONE_PIECE - "원피스"
        &emsp;&emsp;WOMEN_SHOES - "신발"
        &emsp;&emsp;WOMEN_BAG - "가방"
        &emsp;&emsp;WOMEN_ACC - "악세사리"
        &emsp;&emsp;WOMEN_ETC - "기타"
    &emsp;FASHION_MEN - "남성"
        &emsp;&emsp;MEN_OUTER - "아우터"
        &emsp;&emsp;MEN_TOP - "상의"
        &emsp;&emsp;MEN_PANTS - "팬츠"
        &emsp;&emsp;MEN_SHOES - "신발"
        &emsp;&emsp;MEN_BAG - "가방"
        &emsp;&emsp;MEN_ACC - "악세사리"
        &emsp;&emsp;MEN_ETC - "기타"

-----

아이템 목록 조회 메서드 /api/item는 category를 파라미터로 받고
아이템 랭킹 조회 메서드 /api/item/ranking은 category, timeFilter를 파라미터로 받아요

category는 예를들어서 전체 카테고리 조회할 때는 ALL, 여성 아우터 조회할 떄는 WOMEN_OUTER 이런식으로 넣으시면 됩니다.

timeFilter는 int로 받도록 했고 0, 1, 2 각각 
0: 실시간 - 실시간이 무슨 뜻인지 몰라서 일단 "전체 기간 좋아요 많은 순 정렬" 로 했어요
1: 일간 - "오늘 하루동안 좋아요 많이 받은 순 정렬"
2: 주간 - "일주일동안 좋아요 많이 받은 순 정렬"
월간은 깜빡하고 머지해버렸는데 월간도 필요하면 바로 추가 가능해요