### PR TITLE
Feature rapid api search celeb : 몇몇 셀럽 검색 안되던 부분 해결 

### DIFF
--- a/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
+++ b/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
@@ -7,10 +7,8 @@ import com.example.stylescanner.instagram.dto.HomeFeedResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequestMapping("/api/insta")
 @Tag(name="Insta", description = "인스타그램 정보 관련 API")
@@ -26,4 +24,8 @@ public interface InstagramApi {
     @GetMapping("/feed")
     @Operation(summary = "셀럽 계정 속 특정 피드 요청 메서드", description = "선택한 피드의 인덱스값과 미디어 아이디를 넘겨주면 해당 피드의 하위 피드를 가져옵니다.")
     FeedDto getFeed(@RequestBody FeedRequestDto feedRequestDto);
+
+    @PostMapping("/uploadSearchImg")
+    @Operation(summary = "검색용 이미지 업로드 메서드", description = "사용자가 원하는 셀럽 계정이 검색되지 않거나 따로 이미지 검색이 필요할때 검색용 이미지를 서버에 등록하고 url을 반환합니다. ")
+    String uploadSearchImg( @RequestPart(value="SearchImgFile")  MultipartFile searchImgFile);
 }

--- a/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
+++ b/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
@@ -23,7 +23,7 @@ public class InstagramService {
         CelebInstaResponseDto celebInstaResponseDto = new CelebInstaResponseDto();
         try {
             CelebProfileResponseDto celebProfileResponseDto = instagramGraphApiUtil.SearchCeleb(username);
-            List<FeedDto> feedList = instagramGraphApiUtil.GetALlCelebFeed(username);
+            List<FeedDto> feedList = instagramGraphApiUtil.GetCelebInsta(username);
             celebProfileResponseDto.setMediaCount(feedList.size());
             celebInstaResponseDto.setProfile(celebProfileResponseDto);
             celebInstaResponseDto.setFeedList(feedList);


### PR DESCRIPTION
## 업데이트 리스트
- 사용자 검색용 이미지 등록 API -> 셀럽 검색  몇개 안돼서  대안으로 하기로 했던건데 해결해서 안써도 될듯?합니다요 
- **인스타 연동 API 에 서드 파티 API 적용 및 수정** 
- **셀럽 인스타 검색 API 수정 : 모든 피드가 아닌 최근 12개 피드만 반환되도록** 

## 일부 셀럽 검색 안되던 문제 해결 !! 🥹
안유진, 카리나 등등.. 일부 셀럽 검색 안되던 부분을 서드파티 API  사용해서 해결했슴다 

원인은 인스타 파란딱지가 있더라도 비즈니스/크리에이터 계정이 아닐 수도 있어서(파란딱지랑 같은게 아니더라구요 ) 저 계정이 아니면 공식 API 로는 찾을 수 없다네요
근데 특정 셀럽 계정이 비즈니스/크리에이터 계정인지 아닌지 확인할 수 있는 법은 따로 없어서 그냥 공식 API 로 못찾는 셀럽은 서드 파티 API 이용해서 결과 반환되도록 했습니다. 
공식 API 쓴 코드 버리고 다 서드파티 API 로 쓰는 걸로 코드 고치려고 하니 그래도 최대한 공식 API 쓰는게 좋을거 같아서... 

서드 파티 API가 무료 버전은 한달에 500회 호출인데 나중에 프론트에서 연결할때 500회 넘어갈거 같으면 유료로 바꾸겠슴다(한달에 만오천원정도)  
**pr 확인하시고 연락 주시면 서드파티 API 키랑 호스트 주소 카톡으로 보내드릴게용** 


## 셀럽 검색 API 수정 후 결과 (테스트 : 안유진 검색 가능) 
<img width="862" alt="유진 계정 검색" src="https://github.com/user-attachments/assets/739b5847-5482-4b09-902e-1241af73bd76">


## 셀럽 인스타 API 수정 후 결과 (테스트 : 카리나 계정) 
 기존에는 셀럽 검색후 셀럽 계정 클릭시 셀럽 프로필 + 해당 셀럽의 모든 피드가 반환되도록 했는데 뭔가 주요 기능은 아닌데 API 호출 낭비가 심한것 같아서 최근 12개 피드의 섬네일만 반환되도록 수정했습니다. 
<img width="524" alt="image" src="https://github.com/user-attachments/assets/c881c559-9501-4819-afd1-43419d0645c1">




