### PR TITLE
feat: /insta/home pagination 처리 + 하위 미디어 가져오는 API 개발

### DIFF
--- a/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
@@ -2,6 +2,8 @@ package com.example.stylescanner.follow.repository;
 
 import com.example.stylescanner.follow.entity.Follow;
 import com.example.stylescanner.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -33,4 +35,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
             "GROUP BY f.followeeId " +
             "ORDER BY followCount DESC")
     List<Object[]> findTopFollowedCelebrities();
+
+    //paging 추가
+    Page<Follow> findAllByUser(Optional<User> user, Pageable pageable);
 }

--- a/src/main/java/com/example/stylescanner/follow/service/FollowService.java
+++ b/src/main/java/com/example/stylescanner/follow/service/FollowService.java
@@ -14,7 +14,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+
 
 @Service
 public class FollowService {
@@ -172,4 +178,13 @@ public class FollowService {
         }).collect(Collectors.toList());
         return celebRankingResponseDtoList;
     }
+
+    //페이징 처리 : 현재 page에 해당하는 팔로잉 리스트만 보여준다. 페이지 크기는 size 기준
+    public Page<Follow> followingListPaging(String email, int page, int size){
+        Pageable pageable = PageRequest.of(page,size);
+        Optional<User> user = userRepository.findByEmail(email);
+
+        return this.followRepository.findAllByUser(user, pageable);
+    }
+
 }

--- a/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
+++ b/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
@@ -10,6 +10,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.util.List;
+
 @RequestMapping("/api/insta")
 @Tag(name="Insta", description = "인스타그램 정보 관련 API")
 public interface InstagramApi {
@@ -19,11 +22,18 @@ public interface InstagramApi {
 
     @GetMapping("/home")
     @Operation(summary="홈 화면 속 피드 리스트 요청 메서드", description = "사용자가 팔로잉 하고있는 셀럽의 가장 최근 피드를 가져옵니다.")
-    HomeFeedResponseDto getHomeFeed(HttpServletRequest request);
+    List<HomeFeedResponseDto> getHomeFeed(HttpServletRequest request,
+                                    @RequestParam(defaultValue = "0") int page,
+                                    @RequestParam(defaultValue = "9") int size
+                                    ) throws IOException;
 
     @GetMapping("/feed")
     @Operation(summary = "셀럽 계정 속 특정 피드 요청 메서드", description = "선택한 피드의 인덱스값과 미디어 아이디를 넘겨주면 해당 피드의 하위 피드를 가져옵니다.")
     FeedDto getFeed(@RequestBody FeedRequestDto feedRequestDto);
+
+    @GetMapping("/getCarouselMedia")
+    @Operation(summary = "feed_code 로 해당 피드의 하위 미디어들을 가져옵니다. ")
+    List<String> getCarouselMedia(@RequestParam String feed_code) throws IOException;
 
     @PostMapping("/uploadSearchImg")
     @Operation(summary = "검색용 이미지 업로드 메서드", description = "사용자가 원하는 셀럽 계정이 검색되지 않거나 따로 이미지 검색이 필요할때 검색용 이미지를 서버에 등록하고 url을 반환합니다. ")

--- a/src/main/java/com/example/stylescanner/instagram/controller/InstagramController.java
+++ b/src/main/java/com/example/stylescanner/instagram/controller/InstagramController.java
@@ -3,6 +3,7 @@ package com.example.stylescanner.instagram.controller;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.stylescanner.follow.dto.FollowingListResponseDto;
+import com.example.stylescanner.follow.entity.Follow;
 import com.example.stylescanner.follow.service.FollowService;
 import com.example.stylescanner.instagram.api.InstagramApi;
 import com.example.stylescanner.instagram.dto.CelebInstaResponseDto;
@@ -14,11 +15,15 @@ import com.example.stylescanner.jwt.provider.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,16 +43,30 @@ public class InstagramController implements InstagramApi {
         return instagramService.readCelebInsta(username);
     }
 
+//    @Override
+//    public HomeFeedResponseDto getHomeFeed(HttpServletRequest request) {
+//        String email = jwtProvider.getAccount(jwtProvider.resolveToken(request).substring(7));
+//        FollowingListResponseDto followingList =  followService.followingList(email);
+//        return instagramService.readHomeFeed(followingList);
+//    }
+
     @Override
-    public HomeFeedResponseDto getHomeFeed(HttpServletRequest request) {
+    public List<HomeFeedResponseDto> getHomeFeed(HttpServletRequest request, @RequestParam int page, @RequestParam int size) throws IOException {
         String email = jwtProvider.getAccount(jwtProvider.resolveToken(request).substring(7));
-        FollowingListResponseDto followingList =  followService.followingList(email);
-        return instagramService.readHomeFeed(followingList);
+
+        Page<Follow> paging = followService.followingListPaging(email,page,size);
+
+        return instagramService.readHomeFeed(paging);
     }
 
     @Override
     public FeedDto getFeed(FeedRequestDto feedRequestDto) {
         return instagramService.readFeed(feedRequestDto);
+    }
+
+    @Override
+    public List<String> getCarouselMedia(String feed_code) throws IOException {
+        return instagramService.findCarousel(feed_code);
     }
 
     @Override

--- a/src/main/java/com/example/stylescanner/instagram/dto/HomeFeedResponseDto.java
+++ b/src/main/java/com/example/stylescanner/instagram/dto/HomeFeedResponseDto.java
@@ -2,9 +2,18 @@ package com.example.stylescanner.instagram.dto;
 
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+//@Data
+//public class HomeFeedResponseDto {
+//    List<FeedDto> feeds;
+//}
 
 @Data
 public class HomeFeedResponseDto {
-    List<FeedDto> feeds;
+    String username;
+    String profile_url;
+    String thumbnail_url;
+    String feed_code;
 }

--- a/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
+++ b/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
@@ -1,8 +1,10 @@
 package com.example.stylescanner.instagram.service;
 
 import com.example.stylescanner.follow.dto.FollowingListResponseDto;
+import com.example.stylescanner.follow.entity.Follow;
 import com.example.stylescanner.instagram.dto.*;
 import com.example.stylescanner.instagram.util.InstagramGraphApiUtil;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -34,28 +36,51 @@ public class InstagramService {
         return celebInstaResponseDto;
     }
 
-    public HomeFeedResponseDto readHomeFeed(FollowingListResponseDto followingList) {
-        HomeFeedResponseDto homeFeedResponseDto = new HomeFeedResponseDto();
+//    public HomeFeedResponseDto readHomeFeed(FollowingListResponseDto followingList) {
+//        HomeFeedResponseDto homeFeedResponseDto = new HomeFeedResponseDto();
+//
+//        List<FeedDto> AllFeedList = new ArrayList<>();
+//
+//        for(CelebProfileResponseDto celeb : followingList.getFollowing_list()){
+//            String username = celeb.getProfileName();
+//            try {
+//                List<FeedDto> feedList = instagramGraphApiUtil.GetRecentCelebFeed(username);
+//                AllFeedList.addAll(feedList);
+//            } catch (IOException e) {
+//                return null;
+//            }
+//        }
+//
+//        List<FeedDto> sort_AllFeedList =  AllFeedList.stream()
+//                .sorted(Comparator.comparing(FeedDto::getTimestamp).reversed())
+//                .collect(Collectors.toList());
+//
+//        homeFeedResponseDto.setFeeds(sort_AllFeedList);
+//
+//        return homeFeedResponseDto;
+//    }
 
-        List<FeedDto> AllFeedList = new ArrayList<>();
 
-        for(CelebProfileResponseDto celeb : followingList.getFollowing_list()){
-            String username = celeb.getProfileName();
-            try {
-                List<FeedDto> feedList = instagramGraphApiUtil.GetRecentCelebFeed(username);
-                AllFeedList.addAll(feedList);
-            } catch (IOException e) {
-                return null;
-            }
-        }
-
-        List<FeedDto> sort_AllFeedList =  AllFeedList.stream()
-                .sorted(Comparator.comparing(FeedDto::getTimestamp).reversed())
+    public  List<HomeFeedResponseDto> readHomeFeed(Page<Follow> paging) throws IOException {
+        List<String> followingList = paging.getContent().stream()
+                .map(Follow::getFolloweeId)
                 .collect(Collectors.toList());
 
-        homeFeedResponseDto.setFeeds(sort_AllFeedList);
+        List<HomeFeedResponseDto> responseDtos = new ArrayList<>();
+        for(String followeeId : followingList){
+            HomeFeedResponseDto dto = new HomeFeedResponseDto();
+            dto.setUsername(followeeId);
+            dto.setProfile_url(instagramGraphApiUtil.SearchCeleb(followeeId).getProfilePictureUrl());
 
-        return homeFeedResponseDto;
+            FeedDto feedDto = instagramGraphApiUtil.GetRecentCelebFeed_Rapid(followeeId);
+
+            dto.setThumbnail_url(feedDto.getMedia_url_list().get(0));
+            dto.setFeed_code(feedDto.getMedia_id());
+
+            responseDtos.add(dto);
+        }
+
+        return responseDtos;
     }
 
     public FeedDto readFeed(FeedRequestDto feedRequestDto) {
@@ -65,5 +90,9 @@ public class InstagramService {
         String beforeCursor = feedRequestDto.getBefore_cursor();
         String username = feedRequestDto.getUsername();
         return instagramGraphApiUtil.GetMedia(username,  mediaId, beforeCursor,feed_index);
+    }
+
+    public List<String> findCarousel(String feed_code) throws IOException {
+        return instagramGraphApiUtil.GetCarouselMedia(feed_code);
     }
 }


### PR DESCRIPTION
## 수정 및 추가 개발 API 목록

- /api/insta/home  : 기존 홈 피드 API 대폭 수정 (pagination 처리) 
- /api/insta/getCarouselMedia : 홈 피드는 썸네일 피드만 존재, feed_code로 하위 미디어 이미지 가져오는 API 개발 


## API 사용 예 
### /api/insta/home (셀럽 2명씩 가져오는 걸로 했을때,  0번 페이지결과 예시) 
<img width="434" alt="홈 피드 + paging 처리 " src="https://github.com/user-attachments/assets/4fb46c36-f7ec-4c30-8a13-14e8fad84eb9">

page는 0부터 시작입니다!! 그리고 size는 page 크기로 한번에 셀럽 수를 뜻합니다 
서여니가 9명이라고 하긴 했는데 혹시나 나중에 또 적게 가져오고 싶을때가 있을수도 있을까봐 
설정해주는걸로 했슴다 


### /api/insta/getCarouselMedia
위의 home 결과 값 중에서 feed_code를 파라매터에 넣으면, 해당 피드의 하위 이미지 링크만 가져옵니다 
<img width="490" alt="캐서롤 미디어 가져오기 이미지" src="https://github.com/user-attachments/assets/9ce24d73-c0f1-4abf-ac06-93b70489a554">

