### PR TITLE
POST(커뮤니티 게시글) 관련 수정 

### DIFF
--- a/src/main/java/com/example/stylescanner/comment/dto/MyCommentResponseDto.java
+++ b/src/main/java/com/example/stylescanner/comment/dto/MyCommentResponseDto.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 @RequiredArgsConstructor
 public class MyCommentResponseDto {
-    private String feedUrl;
+    private String feedCode;
     private String feedTitle;
     private CommentDto comment;
 }

--- a/src/main/java/com/example/stylescanner/comment/service/CommentService.java
+++ b/src/main/java/com/example/stylescanner/comment/service/CommentService.java
@@ -84,7 +84,7 @@ public class CommentService {
             int post_id = Math.toIntExact(commentDto.getPostId());
             Post post = postRepository.findById(post_id).orElseThrow(() -> new IllegalArgumentException("not found user"));
 
-            myCommentResponseDto.setFeedUrl(post.getFeedUrl());
+            myCommentResponseDto.setFeedCode(post.getFeedCode());
             myCommentResponseDto.setFeedTitle(post.getContent());
 
             myCommentResponseDto.setComment(commentDto);

--- a/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/stylescanner/follow/repository/FollowRepository.java
@@ -38,4 +38,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     //paging 추가
     Page<Follow> findAllByUser(Optional<User> user, Pageable pageable);
+
+    //팔로잉 하고 있는 셀럽 수만 반환하는 메소드 추가
+    int countByUser(@Param("user") Optional<User> user);
 }

--- a/src/main/java/com/example/stylescanner/follow/service/FollowService.java
+++ b/src/main/java/com/example/stylescanner/follow/service/FollowService.java
@@ -210,4 +210,9 @@ public class FollowService {
         return this.followRepository.findAllByUser(user, pageable);
     }
 
+    //팔로잉한 셀럽 수만 반환
+    public int getFollowCountByUser(Optional<User> user){
+        return followRepository.countByUser(user);
+    }
+
 }

--- a/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
+++ b/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
@@ -31,7 +31,7 @@ public interface InstagramApi {
 
     @GetMapping("/getCarouselMedia")
     @Operation(summary = "feed_code 로 해당 피드의 하위 미디어들을 가져옵니다. ")
-    List<String> getCarouselMedia(@RequestParam String feed_code) throws IOException;
+    List<CarouselMediaDto> getCarouselMedia(@RequestParam String feed_code) throws IOException;
 
     @PostMapping("/uploadSearchImg")
     @Operation(summary = "검색용 이미지 업로드 메서드", description = "사용자가 원하는 셀럽 계정이 검색되지 않거나 따로 이미지 검색이 필요할때 검색용 이미지를 서버에 등록하고 url을 반환합니다. ")
@@ -40,4 +40,8 @@ public interface InstagramApi {
     @GetMapping("/proxyImage")
     @Operation(summary = "인스타 이미지 URL을 이미지 파일(byte[])로 반환해줍니다.")
     ResponseEntity<byte[]> getInstagramImage(@RequestParam String imageUrl);
+
+    @GetMapping("/getImageUrl")
+    @Operation(summary = "feedCode로 해당 피드 이미지 url을 찾아서 반환합니다. ", description = "커뮤니티 게시글 작성시, 질문할 피드 이미지의 feedCode는 /home -> /getCarouselMedia 를 거쳐서 얻을수 있고 이를 params에 넣어 호출합니다.  ")
+    String getImageUrl(@RequestParam String feedCode) throws IOException;
 }

--- a/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
+++ b/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
@@ -1,9 +1,6 @@
 package com.example.stylescanner.instagram.api;
 
-import com.example.stylescanner.instagram.dto.CelebInstaResponseDto;
-import com.example.stylescanner.instagram.dto.FeedDto;
-import com.example.stylescanner.instagram.dto.FeedRequestDto;
-import com.example.stylescanner.instagram.dto.HomeFeedResponseDto;
+import com.example.stylescanner.instagram.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,9 +20,9 @@ public interface InstagramApi {
 
     @GetMapping("/home")
     @Operation(summary="홈 화면 속 피드 리스트 요청 메서드", description = "사용자가 팔로잉 하고있는 셀럽의 가장 최근 피드를 가져옵니다.")
-    List<HomeFeedResponseDto> getHomeFeed(HttpServletRequest request,
-                                    @RequestParam(defaultValue = "0") int page,
-                                    @RequestParam(defaultValue = "9") int size
+    HomeFeedDto getHomeFeed(HttpServletRequest request,
+                            @RequestParam(defaultValue = "0") int page,
+                            @RequestParam(defaultValue = "9") int size
                                     ) throws IOException;
 
     @GetMapping("/feed")

--- a/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
+++ b/src/main/java/com/example/stylescanner/instagram/api/InstagramApi.java
@@ -41,7 +41,7 @@ public interface InstagramApi {
     @Operation(summary = "인스타 이미지 URL을 이미지 파일(byte[])로 반환해줍니다.")
     ResponseEntity<byte[]> getInstagramImage(@RequestParam String imageUrl);
 
-    @GetMapping("/getImageUrl")
+    @GetMapping("/getImage")
     @Operation(summary = "feedCode로 해당 피드 이미지 url을 찾아서 반환합니다. ", description = "커뮤니티 게시글 작성시, 질문할 피드 이미지의 feedCode는 /home -> /getCarouselMedia 를 거쳐서 얻을수 있고 이를 params에 넣어 호출합니다.  ")
-    String getImageUrl(@RequestParam String feedCode) throws IOException;
+    ResponseEntity<byte[]> getImage(@RequestParam String feedCode) throws IOException;
 }

--- a/src/main/java/com/example/stylescanner/instagram/controller/InstagramController.java
+++ b/src/main/java/com/example/stylescanner/instagram/controller/InstagramController.java
@@ -60,7 +60,7 @@ public class InstagramController implements InstagramApi {
         List<HomeFeedResponseDto> homeFeedResponseDtoList = instagramService.readHomeFeed(paging);
         HomeFeedDto homeFeedDto = new HomeFeedDto();
 
-        homeFeedDto.setHomeFeedResponseDtoList(homeFeedResponseDtoList);
+        homeFeedDto.setHomeFeedList(homeFeedResponseDtoList);
         homeFeedDto.setTotal_count(followService.getFollowCountByUser(user));
         return homeFeedDto;
     }
@@ -71,7 +71,7 @@ public class InstagramController implements InstagramApi {
     }
 
     @Override
-    public List<String> getCarouselMedia(String feed_code) throws IOException {
+    public List<CarouselMediaDto> getCarouselMedia(String feed_code) throws IOException {
         return instagramService.findCarousel(feed_code);
     }
 
@@ -111,5 +111,10 @@ public class InstagramController implements InstagramApi {
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST); // 예외 처리
         }
+    }
+
+    @Override
+    public String getImageUrl(String feedCode) throws IOException {
+        return instagramService.getImageUrl(feedCode);
     }
 }

--- a/src/main/java/com/example/stylescanner/instagram/controller/InstagramController.java
+++ b/src/main/java/com/example/stylescanner/instagram/controller/InstagramController.java
@@ -114,7 +114,7 @@ public class InstagramController implements InstagramApi {
     }
 
     @Override
-    public String getImageUrl(String feedCode) throws IOException {
-        return instagramService.getImageUrl(feedCode);
+    public ResponseEntity<byte[]> getImage(String feedCode) throws IOException {
+        return this.getInstagramImage(instagramService.getImageUrl(feedCode));
     }
 }

--- a/src/main/java/com/example/stylescanner/instagram/dto/CarouselMediaDto.java
+++ b/src/main/java/com/example/stylescanner/instagram/dto/CarouselMediaDto.java
@@ -1,0 +1,9 @@
+package com.example.stylescanner.instagram.dto;
+
+import lombok.Data;
+
+@Data
+public class CarouselMediaDto {
+    private String feed_url; //바로 이미지 띠울 링크
+    private String feedCode; //이미지 피드 코드
+}

--- a/src/main/java/com/example/stylescanner/instagram/dto/HomeFeedDto.java
+++ b/src/main/java/com/example/stylescanner/instagram/dto/HomeFeedDto.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 @Data
 public class HomeFeedDto {
-    List<HomeFeedResponseDto> homeFeedResponseDtoList;
+    List<HomeFeedResponseDto> homeFeedList;
     int total_count;
 }

--- a/src/main/java/com/example/stylescanner/instagram/dto/HomeFeedDto.java
+++ b/src/main/java/com/example/stylescanner/instagram/dto/HomeFeedDto.java
@@ -1,0 +1,12 @@
+package com.example.stylescanner.instagram.dto;
+
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class HomeFeedDto {
+    List<HomeFeedResponseDto> homeFeedResponseDtoList;
+    int total_count;
+}

--- a/src/main/java/com/example/stylescanner/instagram/dto/HomeFeedResponseDto.java
+++ b/src/main/java/com/example/stylescanner/instagram/dto/HomeFeedResponseDto.java
@@ -2,14 +2,6 @@ package com.example.stylescanner.instagram.dto;
 
 import lombok.Data;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-//@Data
-//public class HomeFeedResponseDto {
-//    List<FeedDto> feeds;
-//}
-
 @Data
 public class HomeFeedResponseDto {
     String username;

--- a/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
+++ b/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
@@ -36,7 +36,7 @@ public class InstagramService {
         return celebInstaResponseDto;
     }
 
-    public  List<HomeFeedResponseDto> readHomeFeed(Page<Follow> paging) throws IOException {
+    public List<HomeFeedResponseDto> readHomeFeed(Page<Follow> paging) throws IOException {
         List<String> followingList = paging.getContent().stream()
                 .map(Follow::getFolloweeId)
                 .collect(Collectors.toList());
@@ -55,6 +55,9 @@ public class InstagramService {
 
             responseDtos.add(dto);
         }
+
+        HomeFeedDto response = new HomeFeedDto();
+        response.setHomeFeedResponseDtoList(responseDtos);
 
         return responseDtos;
     }

--- a/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
+++ b/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
@@ -57,7 +57,7 @@ public class InstagramService {
         }
 
         HomeFeedDto response = new HomeFeedDto();
-        response.setHomeFeedResponseDtoList(responseDtos);
+        response.setHomeFeedList(responseDtos);
 
         return responseDtos;
     }
@@ -71,7 +71,11 @@ public class InstagramService {
         return instagramGraphApiUtil.GetMedia(username,  mediaId, beforeCursor,feed_index);
     }
 
-    public List<String> findCarousel(String feed_code) throws IOException {
+    public List<CarouselMediaDto> findCarousel(String feed_code) throws IOException {
         return instagramGraphApiUtil.GetCarouselMedia(feed_code);
+    }
+
+    public String getImageUrl(String feed_code) throws IOException {
+        return instagramGraphApiUtil.GetImageUrl(feed_code);
     }
 }

--- a/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
+++ b/src/main/java/com/example/stylescanner/instagram/service/InstagramService.java
@@ -5,6 +5,7 @@ import com.example.stylescanner.follow.entity.Follow;
 import com.example.stylescanner.instagram.dto.*;
 import com.example.stylescanner.instagram.util.InstagramGraphApiUtil;
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;

--- a/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
+++ b/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
@@ -5,6 +5,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
@@ -573,8 +574,9 @@ public class InstagramGraphApiUtil {
         if(obj == null) return null;
 
         JSONObject data = obj.getJSONObject("data");
+        String image_url =  data.getJSONObject("image_versions").getJSONArray("items").getJSONObject(0).getString("url");
 
-        return data.getJSONObject("image_versions").getJSONArray("items").getJSONObject(0).getString("url");
+        return image_url;
     }
 
 }

--- a/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
+++ b/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
@@ -1,9 +1,6 @@
 package com.example.stylescanner.instagram.util;
 
-import com.example.stylescanner.instagram.dto.CelebProfileResponseDto;
-import com.example.stylescanner.instagram.dto.FeedDto;
-import com.example.stylescanner.instagram.dto.HomeFeedResponseDto;
-import com.example.stylescanner.instagram.dto.RecentFeedDto;
+import com.example.stylescanner.instagram.dto.*;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -39,7 +36,7 @@ public class InstagramGraphApiUtil {
     private String IG_USER_ID;
 
 
-    //서드 파트 API
+    //서드 파티 API
     @Value("${rapid-instagram-api.host}")
     private String HOST;
 
@@ -539,7 +536,7 @@ public class InstagramGraphApiUtil {
     /*
      피드 검색은 오직 Rapid 만 사용함 -> 공식 API로는 찾을수 없음
      */
-    public List<String> GetCarouselMedia(String feed_code) throws IOException {
+    public List<CarouselMediaDto> GetCarouselMedia(String feed_code) throws IOException {
         String url_format = String.format("https://instagram-scraper-api2.p.rapidapi.com/v1/post_info?code_or_id_or_url=%s&include_insights=true",feed_code);
 
         URL url = new URL(url_format);
@@ -550,16 +547,34 @@ public class InstagramGraphApiUtil {
         JSONObject data = obj.getJSONObject("data");
         JSONArray carousel_media = data.getJSONArray("carousel_media");
 
-        List<String> mediaList = new ArrayList<>();
-
+        List<CarouselMediaDto> carouselMediaDtoList = new ArrayList<>();
         for(int i = 0 ; i < carousel_media.length(); i++) {
             JSONObject media = carousel_media.getJSONObject(i);
             if(!media.getBoolean("is_video")){
-                mediaList.add(media.getJSONObject("image_versions").getJSONArray("items").getJSONObject(0).getString("url"));
+                CarouselMediaDto dto = new CarouselMediaDto();
+                dto.setFeed_url(media.getJSONObject("image_versions").getJSONArray("items").getJSONObject(0).getString("url"));
+
+                String feedCode = media.getString("code");
+                dto.setFeedCode(feedCode);
+
+                carouselMediaDtoList.add(dto);
             }
         }
 
-        return mediaList;
+        return carouselMediaDtoList;
+    }
+
+    public String GetImageUrl(String feed_code) throws IOException {
+        String url_format = String.format("https://instagram-scraper-api2.p.rapidapi.com/v1/post_info?code_or_id_or_url=%s&include_insights=true",feed_code);
+
+        URL url = new URL(url_format);
+        JSONObject obj = GetAPIData_Rapid(url);
+
+        if(obj == null) return null;
+
+        JSONObject data = obj.getJSONObject("data");
+
+        return data.getJSONObject("image_versions").getJSONArray("items").getJSONObject(0).getString("url");
     }
 
 }

--- a/src/main/java/com/example/stylescanner/post/dto/PostCreateDto.java
+++ b/src/main/java/com/example/stylescanner/post/dto/PostCreateDto.java
@@ -7,12 +7,14 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class PostCreateDto {
-    private String feedUrl;
+    private String feedCode;
     private String content;
+    private String username;
 
     @Builder
-    public PostCreateDto(String feedUrl, String content) {
-        this.feedUrl = feedUrl;
+    public PostCreateDto(String feedCode, String content, String username) {
+        this.feedCode = feedCode;
         this.content = content;
+        this.username = username;
     }
 }

--- a/src/main/java/com/example/stylescanner/post/dto/PostDto.java
+++ b/src/main/java/com/example/stylescanner/post/dto/PostDto.java
@@ -14,36 +14,39 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class PostDto {
     private Long id;
-    private String feedUrl;
+    private String feedCode;
     private String content;
     private LocalDateTime createdAt;
     private Long userId;
     private String displayName;
     private String profilePictureUrl;
     private List<CommentDto> comments;
+    private String username;
 
     @Builder
-    public PostDto(Long id, String feedUrl, String content, LocalDateTime createdAt, Long userId, String displayName, String profilePictureUrl, List<CommentDto> comments) {
+    public PostDto(Long id, String feedCode, String content, LocalDateTime createdAt, Long userId, String displayName, String profilePictureUrl, List<CommentDto> comments, String username) {
         this.id = id;
-        this.feedUrl = feedUrl;
+        this.feedCode = feedCode;
         this.content = content;
         this.createdAt = createdAt;
         this.userId = userId;
         this.displayName = displayName;
         this.profilePictureUrl = profilePictureUrl;
         this.comments = comments;
+        this.username = username;
     }
 
     public static PostDto fromEntity(Post post) {
         return PostDto.builder()
                 .id(post.getId())
-                .feedUrl(post.getFeedUrl())
+                .feedCode(post.getFeedCode())
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt())
                 .userId(post.getUser().getId())
                 .displayName(post.getUser().getDisplayName())
                 .profilePictureUrl(post.getUser().getProfilePictureUrl())
                 .comments(post.getComments().stream().map(CommentDto::fromEntity).collect(Collectors.toList()))
+                .username(post.getUsername())
                 .build();
     }
 }

--- a/src/main/java/com/example/stylescanner/post/entity/Post.java
+++ b/src/main/java/com/example/stylescanner/post/entity/Post.java
@@ -22,8 +22,8 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private String feedUrl;
+    @Column(nullable = false) //feedUrl -> feedCode로 수정 , 해당 코드로 이미지 찾는 API 호출할때 사용해서 이미지 불러오기
+    private String feedCode;
 
     @Column(nullable = false)
     private String content;
@@ -39,13 +39,16 @@ public class Post {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(nullable = false)
+    private String username;
 
     @Builder
-    public Post(String feedUrl, String content, LocalDateTime createdAt, User user, List<Comment> comments, String celeb_id) {
-        this.feedUrl = feedUrl;
+    public Post(String feedCode, String content, LocalDateTime createdAt, User user, List<Comment> comments, String username) {
+        this.feedCode = feedCode;
         this.content = content;
         this.createdAt = createdAt;
         this.user = user;
         this.comments = comments;
+        this.username = username;
     }
 }

--- a/src/main/java/com/example/stylescanner/post/service/PostService.java
+++ b/src/main/java/com/example/stylescanner/post/service/PostService.java
@@ -34,8 +34,9 @@ public class PostService {
         User user = userRepository.findByEmail(currentUserEmail).orElseThrow(() -> new IllegalArgumentException("not found user"));
 
         Post post = Post.builder()
-                .feedUrl(postCreateDto.getFeedUrl())
+                .feedCode(postCreateDto.getFeedCode())
                 .content(postCreateDto.getContent())
+                .username(postCreateDto.getUsername()) //셀럽 아이디 추가
                 .createdAt(LocalDateTime.now())
                 .user(user)
                 .build();


### PR DESCRIPTION
## 🔴 머지 전에 Post, comment 데이터 다 밀어주세욥,,, 

### 📜 기존 문제점 및 요청 사항 
> **1. 커뮤니티 피드 이미지 URL의 먹통 문제** 
기존에 직접 post 엔터티의 feedurl에 질문 게시글을 작성할 피드 이미지 링크를 직접 넣어 저장하도록 했는데, 해당 이미지 링크가 영구링크가 아니여서 시간이 지나면 block됨 

> **2. post 게시글 호출 시, 셀럽 정보(username) 도 반환**
프론트 UI 변경으로 인해, 게시글 호출시 셀럽 프로필 정보도 가져오도록 해야하는데 
이때 post(게시글) 별로 어떤 셀럽의 피드에 대한 것인지 특정하지 않아서 찾을수 없었습니다

---

## ⭐⭐수정 및 추가 사항들 

### 1. **POST 엔터티 속성 수정** + **/api/insta/getCarouselMedia** 반환 형식 수정 
feedUrl -> feedCode라는 명칭으로 바꿨습니다. 여기에는 /api/insta/home -> /api/insta/getCarouselMedia의 과정을 통해서
반환되는 feed_code를 저장하도록 해서 해당 피드에 대한 질문 글 작성시 반환되는 feedCode를 POST 에 저장되도록 했습니다 
<img width="448" alt="캐서롤 미디어 수정 버전" src="https://github.com/user-attachments/assets/418d2016-fb02-470c-8ee1-0ac4e5deca72">

따라서 프론트에서 커뮤니티 게시글 정보 호출시 이 feedCode를 이용해서 해당 이미지 URL를 검색하는 API를 호출하도록 해서
피드 이미지 URL을 그때그때 가져와서 이미지 먹통이 되지 않도록 했습니다. 

### 2. /api/insta/getImageUrl : feedCode로 해당 피드 이미지 URL 찾는 API 추가  
위의 1번 과정에서 게시글 정보를 가져올때, feedCode가 반환되면, 본 API를 사용해서 이미지 URL을 얻습니다. 
(근데 생각해보니깐 프록시 문제 때문에 /proxyImage를 또 써야하네요. 그냥 바로 URL이 아니라 이미지 객체 반환되도록 수정할까요?)
<img width="434" alt="이미지 코드로 url 얻기" src="https://github.com/user-attachments/assets/d6eed216-e0a0-45d4-abc6-2f1116e103b0">


### 3. /api/post/create 의 requestbody 형식 수정
게시글 작성시에 username이라는 속성을 추가해서 해당 항목에 현재 피드의 셀럽 아이디를 넣어주도록 수정했습니다. 
그리고 feedUrl이 아닌 feedCode로 명칭을 바꿨습니다. 
<img width="421" alt="커뮤니티 게시글 생성시 수정 사항" src="https://github.com/user-attachments/assets/7197c90a-21af-40d8-9e6e-03cfe3ddbdf7">



