### PR TITLE
/getCarouselMedia 피드 2개 이상 반환시 오류 수정 

### DIFF
--- a/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
+++ b/src/main/java/com/example/stylescanner/instagram/util/InstagramGraphApiUtil.java
@@ -562,9 +562,7 @@ public class InstagramGraphApiUtil {
                     CarouselMediaDto dto = new CarouselMediaDto();
                     dto.setFeed_url(media.getJSONObject("image_versions").getJSONArray("items").getJSONObject(0).getString("url"));
 
-                    String feedCode = media.getString("code");
-                    dto.setFeedCode(feedCode);
-
+                    dto.setFeedCode(feed_code);
                     carouselMediaDtoList.add(dto);
                 }
             }


### PR DESCRIPTION
#### 2개 이상 하위 미디어들도 이제 잘 불러와집니당 
<img width="422" alt="image" src="https://github.com/user-attachments/assets/cc7d0c77-38e2-49e2-b113-4d3feb7bd80e">

#### 1개 미디어도 여전히 잘 불러와짐 
<img width="431" alt="image" src="https://github.com/user-attachments/assets/ad9889f4-4cc4-4cae-998e-051d5c0f13cb">

